### PR TITLE
Filtering borrowings list

### DIFF
--- a/borrowings/models.py
+++ b/borrowings/models.py
@@ -21,9 +21,6 @@ class Borrowing(models.Model):
         if self.expected_return_date < date.today():
             raise ValidationError("Expected return date cannot be in the past.")
 
-        if self.actual_return_date and self.actual_return_date < self.borrow_date:
-            raise ValidationError("Actual return date cannot be before borrow date.")
-
     def save(self, *args, **kwargs):
         self.full_clean()
         return super().save(*args, **kwargs)

--- a/borrowings/serializers.py
+++ b/borrowings/serializers.py
@@ -23,7 +23,7 @@ class BorrowingReadSerializer(serializers.ModelSerializer):
 class BorrowingCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Borrowing
-        fields = ("book", "expected_return_date")
+        fields = ("id", "book", "expected_return_date")
 
     def validate(self, attrs):
         book = attrs["book"]

--- a/borrowings/tests/test_filtering.py
+++ b/borrowings/tests/test_filtering.py
@@ -1,0 +1,100 @@
+from datetime import date, timedelta
+
+from django.urls import reverse
+
+from borrowings.models import Borrowing
+from borrowings.serializers import BorrowingReadSerializer
+from books.models import Book
+from books.tests.base import AuthenticatedAPITestCase
+
+BORROWINGS_URL = reverse("borrowings:borrowing-list")
+
+
+class BorrowingFilterTests(AuthenticatedAPITestCase):
+    def setUp(self):
+        super().setUp()
+        self.book = Book.objects.create(
+            title="Clean Code",
+            author="Robert C. Martin",
+            cover="HARD",
+            inventory=3,
+            daily_fee="1.50",
+        )
+        self.normal_user = self.get_normal_user()
+        self.staff_user = self.get_staff_user()
+
+        self.borrowing1 = Borrowing.objects.create(
+            user=self.normal_user,
+            book=self.book,
+            expected_return_date=date.today() + timedelta(days=3),
+            actual_return_date=None,
+        )
+        self.borrowing2 = Borrowing.objects.create(
+            user=self.normal_user,
+            book=self.book,
+            expected_return_date=date.today() + timedelta(days=5),
+            actual_return_date=date.today(),
+        )
+        self.borrowing3 = Borrowing.objects.create(
+            user=self.staff_user,
+            book=self.book,
+            expected_return_date=date.today() + timedelta(days=2),
+        )
+
+    def test_non_admin_sees_only_own_borrowings(self):
+        self.authenticate_normal_user()
+        res = self.client.get(BORROWINGS_URL)
+
+        borrowings = Borrowing.objects.filter(user=self.normal_user)
+        serializer = BorrowingReadSerializer(borrowings, many=True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, serializer.data)
+
+    def test_admin_sees_all_borrowings(self):
+        self.authenticate_staff_user()
+        res = self.client.get(BORROWINGS_URL)
+
+        borrowings = Borrowing.objects.all()
+        serializer = BorrowingReadSerializer(borrowings, many=True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, serializer.data)
+
+    def test_filter_is_active_true(self):
+        self.authenticate_normal_user()
+        res = self.client.get(BORROWINGS_URL + "?is_active=true")
+
+        borrowings = Borrowing.objects.filter(
+            user=self.normal_user, actual_return_date__isnull=True
+        )
+        serializer = BorrowingReadSerializer(borrowings, many=True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, serializer.data)
+
+    def test_filter_is_active_false(self):
+        self.authenticate_normal_user()
+        res = self.client.get(BORROWINGS_URL + "?is_active=false")
+
+        borrowings = Borrowing.objects.filter(
+            user=self.normal_user, actual_return_date__isnull=False
+        )
+        serializer = BorrowingReadSerializer(borrowings, many=True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, serializer.data)
+
+    def test_admin_filter_by_user_id(self):
+        self.authenticate_staff_user()
+        res = self.client.get(BORROWINGS_URL + f"?user_id={self.normal_user.id}")
+
+        borrowings = Borrowing.objects.filter(user=self.normal_user)
+        serializer = BorrowingReadSerializer(borrowings, many=True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, serializer.data)
+
+    def test_non_admin_cannot_filter_by_user_id(self):
+        self.authenticate_normal_user()
+        res = self.client.get(BORROWINGS_URL + f"?user_id={self.staff_user.id}")
+
+        borrowings = Borrowing.objects.filter(user=self.normal_user)
+        serializer = BorrowingReadSerializer(borrowings, many=True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data, serializer.data)

--- a/borrowings/tests/test_validation.py
+++ b/borrowings/tests/test_validation.py
@@ -31,17 +31,3 @@ class BorrowingModelValidationTests(TestCase):
         with self.assertRaises(ValidationError) as ctx:
             borrowing.full_clean()
         self.assertIn("Expected return date cannot be in the past.", str(ctx.exception))
-
-    def test_actual_return_date_cannot_be_before_borrow_date(self):
-        borrowing = Borrowing(
-            user=self.user,
-            book=self.book,
-            borrow_date=date.today(),
-            expected_return_date=date.today() + timedelta(days=5),
-            actual_return_date=date.today() - timedelta(days=1),
-        )
-        with self.assertRaises(ValidationError) as ctx:
-            borrowing.full_clean()
-        self.assertIn(
-            "Actual return date cannot be before borrow date.", str(ctx.exception)
-        )


### PR DESCRIPTION
Add filtering for the Borrowings List endpoint
--Make sure each non-admin can see only their own borrowings
--Make sure borrowings are available only for authenticated users
--Add the `is_active` parameter for filtering by active borrowings (not returned yet)
--Add the `user_id` parameter for admin users, so admin can see all users’ borrowings, if not specified, but if specified - only for concrete user
